### PR TITLE
Add H option to grep to force output filename when only one file

### DIFF
--- a/simple-grep.js
+++ b/simple-grep.js
@@ -1,7 +1,7 @@
 var grep = function(what, where, callback){
 	var exec = require('child_process').exec;
 
-	exec("grep " + what + " " + where + " -nr", function(err, stdin, stdout){
+	exec("grep " + what + " " + where + " -nrH", function(err, stdin, stdout){
 		var list = {}
 
 		var results = stdin.split('\n');


### PR DESCRIPTION
       -H, --with-filename
              Print  the file name for each match.  This is the default when there is more
              than one file to search.